### PR TITLE
ver 1.4

### DIFF
--- a/poteto.go
+++ b/poteto.go
@@ -54,7 +54,8 @@ type Poteto interface {
 	//    })
 	//  })
 	//  res := p.Play(http.MethodGet, "/users")
-	//  resBodyStr := res.Body.String => {"id":"1","name":"tester"}
+	//  resBodyStr := res.Body.String
+	//  // => {"id":"1","name":"tester"}
 	Play(method, path string, body ...string) *httptest.ResponseRecorder
 }
 

--- a/poteto.go
+++ b/poteto.go
@@ -44,7 +44,17 @@ type Poteto interface {
 	TRACE(path string, handler HandlerFunc) error
 	CONNECT(path string, handler HandlerFunc) error
 
-	// For UT
+	// poteto.Play make ut w/o server
+	// EX:
+	//  p := poteto.New()
+	//  p.GET("/users", func(ctx poteto.Context) error {
+	//    return ctx.JSON(http.StatusOK, map[string]string{
+	//      "id":   "1",
+	//      "name": "tester",
+	//    })
+	//  })
+	//  res := p.Play(http.MethodGet, "/users")
+	//  resBodyStr := res.Body.String => {"id":"1","name":"tester"}
 	Play(method, path string, body ...string) *httptest.ResponseRecorder
 }
 

--- a/practice_test.go
+++ b/practice_test.go
@@ -1,0 +1,41 @@
+package poteto_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/poteto-go/poteto"
+)
+
+func TestPotetoPlay(t *testing.T) {
+	p := poteto.New()
+
+	p.GET("/users", func(ctx poteto.Context) error {
+		return ctx.JSON(http.StatusOK, map[string]string{
+			"id":   "1",
+			"name": "tester",
+		})
+	})
+
+	p.POST("/users", func(ctx poteto.Context) error {
+		var user map[string]string
+		ctx.Bind(user)
+		return ctx.JSON(http.StatusOK, map[string]string{
+			"id":   "1",
+			"name": "tester",
+		})
+	})
+
+	res := p.Play(http.MethodGet, "/users")
+	respBodyStr := res.Body.String()[0 : len(res.Body.String())-1]
+	expected := `{"id":"1","name":"tester"}`
+	if respBodyStr != expected {
+		t.Errorf("unmatched: actual(%s) - expected(%s)", respBodyStr, expected)
+	}
+
+	res2 := p.Play(http.MethodPost, "/users", `{"id":"1","name":"tester"}`)
+	respBodyStr2 := res2.Body.String()[0 : len(res2.Body.String())-1]
+	if respBodyStr2 != expected {
+		t.Errorf("unmatched: actual(%s) - expected(%s)", respBodyStr2, expected)
+	}
+}

--- a/response.go
+++ b/response.go
@@ -74,6 +74,11 @@ func (r *response) Header() http.Header {
 	return r.Writer.Header()
 }
 
+// fullfil interface for responseController
+// you can assign to responseController
+// res := NewResponse(w)
+// rc := http.NewResponseController(res)
+// https://go.dev/src/net/http/responsecontroller.go
 func (r *response) Unwrap() http.ResponseWriter {
 	return r.Writer
 }

--- a/response.go
+++ b/response.go
@@ -14,6 +14,7 @@ type Response interface {
 	Header() http.Header
 	SetHeader(key, value string)
 	AddHeader(key, value string)
+	Unwrap() http.ResponseWriter
 }
 
 type response struct {
@@ -71,4 +72,8 @@ func (r *response) SetStatus(code int) {
 
 func (r *response) Header() http.Header {
 	return r.Writer.Header()
+}
+
+func (r *response) Unwrap() http.ResponseWriter {
+	return r.Writer
 }

--- a/response_test.go
+++ b/response_test.go
@@ -93,3 +93,15 @@ func TestSetHeader(t *testing.T) {
 		t.Error("Unmatched")
 	}
 }
+
+func TestUnwrapResponse(t *testing.T) {
+	w := httptest.NewRecorder()
+
+	res := NewResponse(w)
+
+	var wi http.ResponseWriter = nil
+	wi = res.Unwrap()
+	if wi == nil {
+		t.Error("cannot unwrap response")
+	}
+}

--- a/response_test.go
+++ b/response_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 )
 
 func TestWriteHeader(t *testing.T) {
@@ -104,4 +105,13 @@ func TestUnwrapResponse(t *testing.T) {
 	if wi == nil {
 		t.Error("cannot unwrap response")
 	}
+}
+
+func TestResponseController(t *testing.T) {
+	w := httptest.NewRecorder()
+
+	res := NewResponse(w)
+	rc := http.NewResponseController(res)
+	rc.SetWriteDeadline(time.Now().Add(5 * time.Second))
+	res.Write([]byte("done"))
 }


### PR DESCRIPTION
## ResponseController
https://go.dev/src/net/http/responsecontroller.go

## Change
- FEAT: `response` fullfill interface for `ReponseController`
### Issue
- #225 
```go
w := httptest.NewRecorder()
res := NewResponse(w)
rc := http.NewResponseController(res)
rc.SetWriteDeadline(time.Now().Add(5 * time.Second))
res.Write([]byte("done"))
```
- FEAT: `poteto.Play` for ut w/o server
### Issue
- #227
```go
func main() {
	p := poteto.New()

	p.GET("/users", func(ctx poteto.Context) error {
		return ctx.JSON(http.StatusOK, map[string]string{
			"id":   "1",
			"name": "tester",
		})
	})

	res := p.Play(http.MethodGet, "/users")
	resBodyStr := res.Body.String
	// => {"id":"1","name":"tester"}
}
```
## Version
It will be `v1.4.0`