### PR TITLE
20250327/OIDC

### DIFF
--- a/middleware/jws.go
+++ b/middleware/jws.go
@@ -10,7 +10,7 @@ import (
 	"github.com/poteto-go/poteto/constant"
 )
 
-type potetoJWSConfig struct {
+type PotetoJWSConfig struct {
 	AuthScheme string
 	SignMethod string
 	SignKey    any
@@ -18,12 +18,12 @@ type potetoJWSConfig struct {
 	ClaimsFunc func(c poteto.Context) jwt.Claims
 }
 
-type PotetoJWSConfig interface {
+type IPotetoJWSConfig interface {
 	KeyFunc(token *jwt.Token) (any, error)
 	ParseToken(ctx poteto.Context, auth string) (any, error)
 }
 
-var DefaultJWSConfig = &potetoJWSConfig{
+var DefaultJWSConfig = &PotetoJWSConfig{
 	AuthScheme: constant.AuthScheme,
 	SignMethod: constant.AlgorithmHS256,
 	ContextKey: "user",
@@ -32,14 +32,7 @@ var DefaultJWSConfig = &potetoJWSConfig{
 	},
 }
 
-func NewPotetoJWSConfig(contextKey string, signKey any) PotetoJWSConfig {
-	cfg := DefaultJWSConfig
-	cfg.ContextKey = contextKey
-	cfg.SignKey = signKey
-	return cfg
-}
-
-func (cfg *potetoJWSConfig) KeyFunc(token *jwt.Token) (any, error) {
+func (cfg *PotetoJWSConfig) KeyFunc(token *jwt.Token) (any, error) {
 	if token.Method.Alg() != cfg.SignMethod {
 		return nil, errors.New("unexpected jwt signing method: " + cfg.SignMethod)
 	}
@@ -51,7 +44,7 @@ func (cfg *potetoJWSConfig) KeyFunc(token *jwt.Token) (any, error) {
 	return cfg.SignKey, nil
 }
 
-func (cfg *potetoJWSConfig) ParseToken(ctx poteto.Context, auth string) (any, error) {
+func (cfg *PotetoJWSConfig) ParseToken(ctx poteto.Context, auth string) (any, error) {
 	token, err := jwt.ParseWithClaims(auth, cfg.ClaimsFunc(ctx), cfg.KeyFunc)
 	if err != nil {
 		return nil, err
@@ -62,8 +55,8 @@ func (cfg *potetoJWSConfig) ParseToken(ctx poteto.Context, auth string) (any, er
 	return token, nil
 }
 
-func JWSWithConfig(cfg PotetoJWSConfig) poteto.MiddlewareFunc {
-	config := cfg.(*potetoJWSConfig)
+func JWSWithConfig(cfg IPotetoJWSConfig) poteto.MiddlewareFunc {
+	config := cfg.(*PotetoJWSConfig)
 	if config.SignKey == nil {
 		panic(config.SignKey)
 	}

--- a/middleware/oidc.go
+++ b/middleware/oidc.go
@@ -1,0 +1,102 @@
+package middleware
+
+import (
+	"encoding/base64"
+	"errors"
+	"strings"
+
+	"github.com/goccy/go-json"
+	"github.com/poteto-go/poteto"
+	"github.com/poteto-go/poteto/oidc"
+)
+
+type OidcConfig struct {
+	// google
+	Idp        string `yaml:"idp"`
+	ContextKey string `yaml:"context_key"`
+}
+
+var DefaultOidcConfig = &OidcConfig{
+	Idp:        "google",
+	ContextKey: "googleToken",
+}
+
+// Oidc support google.com
+//
+// case google: => oidc.GoogleOidcClaims
+//
+//	func main() {
+//	  p := poteto.New()
+//	  p.Register(
+//	    middleware.OidcWithConfig(
+//	      middleware.DefaultOidcConfig,
+//	    )
+//	  )
+//	  p.POST("/login", func(ctx poteto.Context) error {
+//	      token, _ := ctx.Get("googleToken")
+//	      claims := token.(oidc.GoogleOidcClaims)
+//	   })
+//	}
+//
+// case other: => return []byte
+func OidcWithConfig(cfg OidcConfig) poteto.MiddlewareFunc {
+	if cfg.ContextKey == "" {
+		cfg.ContextKey = DefaultOidcConfig.ContextKey
+	}
+
+	if cfg.Idp == "" {
+		cfg.Idp = DefaultOidcConfig.Idp
+	}
+
+	var claims any
+	switch cfg.Idp {
+	case "google":
+		claims = oidc.GoogleOidcClaims{}
+	}
+
+	return func(next poteto.HandlerFunc) poteto.HandlerFunc {
+		return func(ctx poteto.Context) error {
+			authValue, err := extractBearer(ctx)
+			if err != nil {
+				return err
+			}
+
+			token, err := decode(authValue)
+			if err != nil {
+				return err
+			}
+
+			// unmarshal
+			switch cfg.Idp {
+			case "google":
+				json.Unmarshal(token, &claims)
+				ctx.Set(cfg.ContextKey, claims)
+			default:
+				ctx.Set(cfg.ContextKey, token)
+				return next(ctx)
+			}
+
+			return next(ctx)
+		}
+	}
+}
+
+func decode(token string) ([]byte, error) {
+	splitToken := strings.Split(token, ".")
+	if len(splitToken) != 3 {
+		return []byte(""), errors.New("invalid token")
+	}
+	payload := splitToken[1]
+
+	// base64 needs 4* length
+	paddingLength := ((4 - len(payload)%4) % 4)
+	padding := strings.Repeat("=", paddingLength)
+	paddedPayload := strings.Join([]string{payload, padding}, "")
+
+	decodedPayload, err := base64.StdEncoding.DecodeString(paddedPayload)
+	if err != nil {
+		return []byte(""), err
+	}
+
+	return decodedPayload, nil
+}

--- a/middleware/oidc_test.go
+++ b/middleware/oidc_test.go
@@ -41,4 +41,27 @@ func TestMiddleware_OidcWithConfig(t *testing.T) {
 
 		assert.Equal(t, claims.Email, "test@exmaple.com")
 	})
+
+	t.Run("invalid token", func(t *testing.T) {
+		token := "invalid"
+
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", "/", nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+
+		ctx := poteto.NewContext(w, req)
+
+		var claims oidc.GoogleOidcClaims
+		handler := func(ctx poteto.Context) error {
+			token, _ := ctx.Get("googleToken")
+			json.Unmarshal(token.([]byte), &claims)
+
+			return ctx.JSON(http.StatusOK, claims)
+		}
+		oidc_handler := oidcMiddleware(handler)
+
+		err := oidc_handler(ctx)
+
+		assert.NotNil(t, err)
+	})
 }

--- a/middleware/oidc_test.go
+++ b/middleware/oidc_test.go
@@ -1,0 +1,44 @@
+package middleware_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/goccy/go-json"
+	"github.com/poteto-go/poteto"
+	"github.com/poteto-go/poteto/middleware"
+	"github.com/poteto-go/poteto/oidc"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMiddleware_OidcWithConfig(t *testing.T) {
+	oidcMiddleware := middleware.OidcWithConfig(
+		middleware.DefaultOidcConfig,
+	)
+
+	t.Run("valid token", func(t *testing.T) {
+		token := "eyJhbGciOiJSUzI1NiIsImtpZCI6ImtleUlkIiwidHlwIjoiSldUIn0.eyJpc3MiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb20iLCJhenAiOiJleG1hcGxlLmFwcHMuZ29vZ2xldXNlcmNvbnRlbnQuY29tIiwiYXVkIjoiZXhtYXBsZS5hcHBzLmdvb2dsZXVzZXJjb250ZW50LmNvbSIsInN1YiI6IjEwMDAwMDAwMDAwMDAwMDAiLCJlbWFpbCI6InRlc3RAZXhtYXBsZS5jb20iLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwiYXRfaGFzaCI6Imhhc2giLCJuYW1lIjoiVGVzdCBVc2VyIiwicGljdHVyZSI6Imh0dHBzOi8vcGljdHVyZSIsImdpdmVuX25hbWUiOiJUZXN0IiwiZmFtaWx5X25hbWUiOiJVc2VyIiwiaWF0IjoxNzQzMDc2MTk4LCJleHAiOjE3NDMwNzk3OTh9.pPriv3JvTgtQectH3mfOcMSO6T2RmWOMjyCXl4qd5_2tZNLfUh1M4f2JAqyectfrS1c4515k92_kKRN5985GHS78etadEH-0lFW7T3ehfYD5fs0HVo0EwYlDTg_8tZZ4x8kWd_RPdg21BQiubnHWcIpFv-HyMI9mWrkCmw31bkMrS-5a5-CMfeZwh2kJaD8D1_84LLuQuzbzIEBXoDlWCwHVkMTx6MSXNJpSqakCcDpE_sZ1WMg4r2jNvsG3nT-jSKwTMZ4g960YfYW0BAQafUKKDOZM9JnQ0HrFHEnKAun83AHjjmGVu3bq7Jc4IqQ5sYVuZD7BeciaEvQKvsk3IA"
+
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", "/", nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+
+		ctx := poteto.NewContext(w, req)
+
+		var claims oidc.GoogleOidcClaims
+		handler := func(ctx poteto.Context) error {
+			token, _ := ctx.Get("googleToken")
+			json.Unmarshal(token.([]byte), &claims)
+
+			return ctx.JSON(http.StatusOK, claims)
+		}
+		oidc_handler := oidcMiddleware(handler)
+
+		oidc_handler(ctx)
+
+		assert.Equal(t, claims.Iss, "https://accounts.google.com")
+
+		assert.Equal(t, claims.Email, "test@exmaple.com")
+	})
+}

--- a/oidc/google.go
+++ b/oidc/google.go
@@ -1,0 +1,17 @@
+package oidc
+
+type GoogleOidcClaims struct {
+	Iss           string `json:"iss"`
+	Azp           string `json:"azp"`
+	Aud           string `json:"aud"`
+	Sub           string `json:"sub"`
+	Email         string `json:"email"`
+	EmailVerified bool   `json:"email_verified"`
+	AtHash        string `json:"at_hash"`
+	Name          string `json:"name"`
+	Picture       string `json:"picture"`
+	GivenName     string `json:"given_name"`
+	FamilyName    string `json:"family_name"`
+	Iat           int64  `json:"iat"`
+	Exp           int64  `json:"exp"`
+}


### PR DESCRIPTION
## Check

- [x] I've checked pass linter \* required
- [x] I've checked pass ut \* required
- [x] I've written ut for change

## Change
- FEAT: client oidc token & parse it (support google format)
```go
func main() {
  p := poteto.New()
  p.Register(
    middleware.OidcWithConfig(
      middleware.DefaultOidcConfig,
    )
  )

  p.POST("/login", func(ctx poteto.Context) error {
    var claims oidc.GoogleOidcClaims
    token, _ := ctx.Get("googleToken")
    json.Unmarshal(token.([]byte), &claims)
  })
}
```
- BUG: make jwsConfig public

## Issue
- https://github.com/poteto-go/poteto/issues/280
- https://github.com/poteto-go/poteto/issues/281