### PR TITLE
ENH: cache jwk on oidc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # 1.x.x
 
+## 1.10.X
+
+@2025/04/07 ~
+
+### 1.10.0
+
+@2025/04/07 ~
+
+- FEAT: cache (jwk) mode for oidc by @poteto in #295
+
+```go
+// new oidc with cache mode
+oidcConfig := middleware.OidcConfig {
+  Idp: "google",
+  ContextKey: "googleToken",
+  CacheMode: true,
+  JwksUrl: "https://www.googleapis.com/oauth2/v3/certs",
+  CachedVerifyTokenSignature: oidc.CachedVerifyTokenSignature,
+}
+
+p.Register(
+  middleware.OidcWithConfig(
+    oidcConfig,
+  )
+)
+```
+
 ## 1.9.X
 
 @2025/03/30 ~

--- a/README.md
+++ b/README.md
@@ -84,10 +84,11 @@ func main() {
   p := poteto.New()
 
   oidcConfig := middleware.OidcConfig {
-    Idp: "google",
-    ContextKey: "googleToken",
+	  Idp: "google",
+		ContextKey: "googleToken",
+    CacheMode: true,
     JwksUrl: "https://www.googleapis.com/oauth2/v3/certs",
-    CustomVerifyTokenSignature: oidc.DefaultVerifyTokenSignature,
+    CachedVerifyTokenSignature: oidc.CachedVerifyTokenSignature,
   }
   p.Register(
     middleware.OidcWithConfig(

--- a/constant/constants.go
+++ b/constant/constants.go
@@ -1,6 +1,6 @@
 package constant
 
-const Version = "v1.9.1"
+const Version = "v1.10.0"
 
 const (
 	// max length of domain /

--- a/constant/old_constants.go
+++ b/constant/old_constants.go
@@ -1,6 +1,6 @@
 package constant
 
-const VERSION = "v1.9.1"
+const VERSION = "v1.10.0"
 
 const (
 	MAX_DOMAIN_LENGTH      int    = 255

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
+	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/crypto v0.35.0 // indirect
 	golang.org/x/exp v0.0.0-20250210185358-939b2ce775ac // indirect

--- a/go.sum
+++ b/go.sum
@@ -35,6 +35,8 @@ github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovk
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
+github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/poteto-go/tslice v0.4.0 h1:AihA32BmSW4a/FpnzO8yjUbclr0XxGyuBc2rpHvxb8A=

--- a/middleware/oidc.go
+++ b/middleware/oidc.go
@@ -58,7 +58,7 @@ var DefaultOidcConfig = OidcConfig{
 //	  oidcConfig := middleware.OidcConfig {
 //	    Idp: "google",
 //	    ContextKey: "googleToken",
-//	      CacheMode: true,
+//	    CacheMode: true,
 //	    JwksUrl: "https://www.googleapis.com/oauth2/v3/certs",
 //	    CachedVerifyTokenSignature: oidc.CachedVerifyTokenSignature,
 //	  }

--- a/middleware/oidc.go
+++ b/middleware/oidc.go
@@ -3,32 +3,50 @@ package middleware
 import (
 	"errors"
 	"strings"
+	"time"
 
+	"github.com/patrickmn/go-cache"
 	"github.com/poteto-go/poteto"
 	"github.com/poteto-go/poteto/oidc"
 	"github.com/poteto-go/poteto/utils"
 )
 
 type OidcConfig struct {
-	Idp        string `yaml:"idp"`
-	ContextKey string `yaml:"context_key"`
-	JwksUrl    string `yaml:"jwks_url"`
+	Idp               string        `yaml:"idp"`
+	ContextKey        string        `yaml:"context_key"`
+	JwksUrl           string        `yaml:"jwks_url"`
+	DefaultExpiration time.Duration `yaml:"default_expiration"`
+	CleanupInterval   time.Duration `yaml:"cleanup_interval"`
+	CacheMode         bool          `yaml:"cache_mode"`
+	Cache             *cache.Cache  `yaml:"-"`
 	// you can set custom verify signature callback
-	CustomVerifyTokenSignature func(idToken oidc.IdToken, jwksUrl string) error `yaml:"-"`
+	CustomVerifyTokenSignature func(idToken oidc.IdToken, jwksUrl string) error                      `yaml:"-"`
+	CachedVerifyTokenSignature func(idToken oidc.IdToken, pCache *cache.Cache, jwksUrl string) error `yaml:"-"`
 }
 
 var OidcWithoutVerifyConfig = OidcConfig{
-	Idp:                        "google",
-	ContextKey:                 "googleToken",
-	JwksUrl:                    "",
+	Idp:               "google",
+	ContextKey:        "googleToken",
+	JwksUrl:           "",
+	DefaultExpiration: cache.DefaultExpiration,
+	CleanupInterval:   (24 * time.Hour),
+	// default [true] at v2
+	CacheMode:                  false,
+	Cache:                      nil,
 	CustomVerifyTokenSignature: nil,
 }
 
 var DefaultOidcConfig = OidcConfig{
-	Idp:                        "google",
-	ContextKey:                 "googleToken",
-	JwksUrl:                    "",
+	Idp:               "google",
+	ContextKey:        "googleToken",
+	JwksUrl:           "",
+	DefaultExpiration: cache.DefaultExpiration,
+	CleanupInterval:   (24 * time.Hour),
+	// default [true] at v2
+	CacheMode:                  true,
+	Cache:                      nil,
 	CustomVerifyTokenSignature: oidc.DefaultVerifyTokenSignature,
+	CachedVerifyTokenSignature: oidc.CachedVerifyTokenSignature,
 }
 
 // Oidc verify signature by jwks url & set token -> context
@@ -40,8 +58,9 @@ var DefaultOidcConfig = OidcConfig{
 //	  oidcConfig := middleware.OidcConfig {
 //	    Idp: "google",
 //	    ContextKey: "googleToken",
+//	      CacheMode: true,
 //	    JwksUrl: "https://www.googleapis.com/oauth2/v3/certs",
-//	      CustomVerifyTokenSignature: oidc.DefaultVerifyTokenSignature,
+//	    CachedVerifyTokenSignature: oidc.CachedVerifyTokenSignature,
 //	  }
 //	  p.Register(
 //	    middleware.OidcWithConfig(
@@ -69,6 +88,18 @@ func OidcWithConfig(cfg OidcConfig) poteto.MiddlewareFunc {
 		cfg.JwksUrl = oidc.JWKsUrls[cfg.Idp]
 	}
 
+	if cfg.DefaultExpiration == 0 {
+		cfg.DefaultExpiration = DefaultOidcConfig.DefaultExpiration
+	}
+
+	if cfg.CleanupInterval == 0 {
+		cfg.CleanupInterval = DefaultOidcConfig.CleanupInterval
+	}
+
+	if cfg.CacheMode && cfg.Cache == nil {
+		cfg.Cache = cache.New(cfg.DefaultExpiration, cfg.CleanupInterval)
+	}
+
 	return func(next poteto.HandlerFunc) poteto.HandlerFunc {
 		return func(ctx poteto.Context) error {
 			authValue, err := extractBearer(ctx)
@@ -76,7 +107,7 @@ func OidcWithConfig(cfg OidcConfig) poteto.MiddlewareFunc {
 				return err
 			}
 
-			token, err := verifyDecode(authValue, cfg.JwksUrl, cfg.CustomVerifyTokenSignature)
+			token, err := verifyDecode(authValue, cfg)
 			if err != nil {
 				return err
 			}
@@ -87,7 +118,7 @@ func OidcWithConfig(cfg OidcConfig) poteto.MiddlewareFunc {
 	}
 }
 
-func verifyDecode(token, jwksUrl string, customVerifyTokenSignature func(oidc.IdToken, string) error) ([]byte, error) {
+func verifyDecode(token string, cfg OidcConfig) ([]byte, error) {
 	splitToken := strings.Split(token, ".")
 	if len(splitToken) != 3 {
 		return []byte(""), errors.New("invalid token")
@@ -100,11 +131,9 @@ func verifyDecode(token, jwksUrl string, customVerifyTokenSignature func(oidc.Id
 		RawSignature: splitToken[2],
 	}
 
-	if customVerifyTokenSignature != nil {
-		err := customVerifyTokenSignature(idToken, jwksUrl)
-		if err != nil {
-			return []byte(""), err
-		}
+	// verify
+	if err := applyVerifyFunc(idToken, cfg); err != nil {
+		return []byte(""), err
 	}
 
 	// decode payload
@@ -114,4 +143,19 @@ func verifyDecode(token, jwksUrl string, customVerifyTokenSignature func(oidc.Id
 	}
 
 	return decodedPayload, nil
+}
+
+func applyVerifyFunc(idToken oidc.IdToken, cfg OidcConfig) error {
+	if cfg.CacheMode {
+		if cfg.CachedVerifyTokenSignature != nil {
+			return cfg.CachedVerifyTokenSignature(idToken, cfg.Cache, cfg.JwksUrl)
+		}
+		return nil
+	}
+
+	if cfg.CustomVerifyTokenSignature != nil {
+		return cfg.CustomVerifyTokenSignature(idToken, cfg.JwksUrl)
+	}
+
+	return nil
 }

--- a/oidc/verify_test.go
+++ b/oidc/verify_test.go
@@ -12,9 +12,11 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic" // For request counting
 	"testing"
 	"time"
 
+	"github.com/patrickmn/go-cache" // Import go-cache
 	"github.com/poteto-go/poteto/utils"
 	"github.com/stretchr/testify/assert"
 )
@@ -249,6 +251,219 @@ func TestDefaultVerifyTokenSignature(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 			}
+		})
+	}
+}
+
+func TestCachedVerifyTokenSignature(t *testing.T) {
+	// Generate RSA key pair for signing and verification
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	assert.NoError(t, err)
+	publicKey := &privateKey.PublicKey
+
+	// --- Test Setup ---
+	kid := "test-key-id-cache-1"
+	testHeader := Header{
+		Alg: "RS256",
+		Typ: "JWT",
+		Kid: kid,
+	}
+	testPayload := map[string]interface{}{
+		"iss": "https://test.issuer.com",
+		"sub": "test-subject-cache",
+		"aud": "test-audience-cache",
+		"exp": time.Now().Add(time.Hour).Unix(),
+		"iat": time.Now().Unix(),
+	}
+
+	// Create a valid token
+	validToken, err := createTestJWT(testHeader, testPayload, privateKey)
+	assert.NoError(t, err)
+
+	// Create JWK corresponding to the public key
+	correctJWK := createJWK(publicKey, kid)
+	jwksResponse := jwks{Keys: []jwk{correctJWK}}
+	jwksBytes, err := json.Marshal(jwksResponse)
+	assert.NoError(t, err)
+
+	// --- Mock JWKS Server with Request Counter ---
+	var requestCount int32 // Use atomic counter for thread safety if tests run in parallel (though not strictly needed here)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&requestCount, 1) // Increment counter on each request
+		if r.URL.Path == "/.well-known/jwks.json" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(jwksBytes)
+		} else {
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+	jwksUrl := server.URL + "/.well-known/jwks.json"
+
+	// --- Cache Instance ---
+	// Use short expiration for testing, though DefaultExpiration is used in the actual function
+	pCache := cache.New(5*time.Minute, 10*time.Minute)
+
+	// --- Test Cases ---
+	t.Run("Valid Token - Cache Miss then Hit", func(t *testing.T) {
+		// Reset request counter and cache for this specific test
+		atomic.StoreInt32(&requestCount, 0)
+		pCache.Flush() // Clear cache before test
+
+		// 1. First call (Cache Miss)
+		err := CachedVerifyTokenSignature(validToken, pCache, jwksUrl)
+		assert.NotNil(t, err)
+		assert.Equal(t, int32(1), atomic.LoadInt32(&requestCount), "JWKS should be requested on first call")
+
+		// Verify key is cached
+		_, found := pCache.Get(jwksUrl)
+		assert.True(t, found, "JWK should be cached after first call")
+
+		// 2. Second call (Cache Hit)
+		err = CachedVerifyTokenSignature(validToken, pCache, jwksUrl)
+		assert.NoError(t, err, "Second call should succeed")
+		assert.Equal(t, int32(1), atomic.LoadInt32(&requestCount), "JWKS should NOT be requested on second call (cache hit)")
+	})
+
+	t.Run("Invalid Signature", func(t *testing.T) {
+		atomic.StoreInt32(&requestCount, 0)
+		pCache.Flush()
+		invalidSigToken := IdToken{
+			RawHeader:    validToken.RawHeader,
+			RawPayload:   validToken.RawPayload,
+			RawSignature: strings.TrimRight(base64.RawURLEncoding.EncodeToString([]byte("invalid")), "="),
+			Header:       validToken.Header,
+		}
+		err := CachedVerifyTokenSignature(invalidSigToken, pCache, jwksUrl)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "signature verification failed")
+		// JWKS might still be fetched and cached even if signature fails later
+		assert.Equal(t, int32(1), atomic.LoadInt32(&requestCount), "JWKS should be requested even if signature is invalid")
+		_, found := pCache.Get(jwksUrl)
+		assert.True(t, found, "JWK should be cached even if signature verification fails")
+	})
+
+	t.Run("Malformed Header Segment", func(t *testing.T) {
+		atomic.StoreInt32(&requestCount, 0)
+		pCache.Flush()
+		malformedHeaderToken := IdToken{
+			RawHeader:    "not-base64",
+			RawPayload:   validToken.RawPayload,
+			RawSignature: validToken.RawSignature,
+		}
+		err := CachedVerifyTokenSignature(malformedHeaderToken, pCache, jwksUrl)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "illegal base64 data")
+		assert.Equal(t, int32(0), atomic.LoadInt32(&requestCount), "JWKS should not be requested if header decoding fails")
+		_, found := pCache.Get(jwksUrl)
+		assert.False(t, found, "JWK should not be cached if header decoding fails")
+	})
+
+	t.Run("Malformed Signature Segment", func(t *testing.T) {
+		atomic.StoreInt32(&requestCount, 0)
+		pCache.Flush()
+		malformedSigToken := IdToken{
+			RawHeader:    validToken.RawHeader,
+			RawPayload:   validToken.RawPayload,
+			RawSignature: "not-base64!", // Invalid base64
+			Header:       validToken.Header,
+		}
+		err := CachedVerifyTokenSignature(malformedSigToken, pCache, jwksUrl)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "illegal base64 data")
+		// JWKS is fetched before signature decoding
+		assert.Equal(t, int32(1), atomic.LoadInt32(&requestCount), "JWKS should be requested before signature decoding")
+		_, found := pCache.Get(jwksUrl)
+		assert.True(t, found, "JWK should be cached even if signature decoding fails")
+	})
+
+	t.Run("Key ID (kid) Not Found in JWKS", func(t *testing.T) {
+		atomic.StoreInt32(&requestCount, 0)
+		pCache.Flush()
+		headerWithWrongKid := Header{Alg: "RS256", Typ: "JWT", Kid: "wrong-kid"}
+		tokenWithWrongKid, _ := createTestJWT(headerWithWrongKid, testPayload, privateKey)
+
+		err := CachedVerifyTokenSignature(tokenWithWrongKid, pCache, jwksUrl)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "jwks keys not found")
+		assert.Equal(t, int32(1), atomic.LoadInt32(&requestCount), "JWKS should be requested when kid is not found")
+		_, found := pCache.Get(jwksUrl)
+		assert.False(t, found, "JWK should not be cached if kid is not found") // Key not found, so nothing to cache for this URL/kid combo
+	})
+
+	// --- Test JWKS Server Errors (Cache should not be populated) ---
+	jwksErrorTests := []struct {
+		name        string
+		setupServer func() *httptest.Server
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			name: "JWKS Server Down",
+			setupServer: func() *httptest.Server {
+				s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					// No response, simulate down
+				}))
+				s.Close() // Close immediately
+				return s
+			},
+			expectError: true,
+			errorMsg:    "failed to GET JWKs endpoint",
+		},
+		{
+			name: "JWKS Server Returns 500",
+			setupServer: func() *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					atomic.AddInt32(&requestCount, 1) // Count request even on error
+					w.WriteHeader(http.StatusInternalServerError)
+				}))
+			},
+			expectError: true,
+			errorMsg:    "failed to unmarshal JWKs response", // Likely error due to empty body
+		},
+		{
+			name: "JWKS Server Returns Malformed JSON",
+			setupServer: func() *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					atomic.AddInt32(&requestCount, 1) // Count request
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte("{not json}"))
+				}))
+			},
+			expectError: true,
+			errorMsg:    "failed to unmarshal JWKs response",
+		},
+	}
+
+	for _, it := range jwksErrorTests {
+		t.Run(it.name, func(t *testing.T) {
+			atomic.StoreInt32(&requestCount, 0) // Reset counter for each server error test
+			pCache.Flush()                      // Clear cache
+
+			currentServer := it.setupServer()
+			// Use a different path or ensure the server URL is unique if needed,
+			// but using the same path structure is fine here.
+			currentJwksUrl := currentServer.URL + "/.well-known/jwks.json"
+			defer currentServer.Close()
+
+			err := CachedVerifyTokenSignature(validToken, pCache, currentJwksUrl)
+
+			if it.expectError {
+				assert.Error(t, err)
+				if it.errorMsg != "" {
+					assert.Contains(t, err.Error(), it.errorMsg)
+				}
+				// Request might have been made depending on the error type
+				// assert.Equal(t, int32(1), atomic.LoadInt32(&requestCount), "JWKS request should be attempted")
+			} else {
+				assert.NoError(t, err)
+			}
+
+			// Ensure cache is not populated on JWKS fetch error
+			_, found := pCache.Get(currentJwksUrl)
+			assert.False(t, found, "JWK should not be cached when JWKS fetch fails")
 		})
 	}
 }


### PR DESCRIPTION
## Check

- [x] I've checked pass linter \* required
- [x] I've checked pass ut \* required
- [ ] I've written ut for change

## Change

- ENH: cache jwk on oidc

## Issue

- https://github.com/poteto-go/poteto/issues/294