### PR TITLE
patch: set error handler

### DIFF
--- a/error_handler.go
+++ b/error_handler.go
@@ -4,13 +4,8 @@ import (
 	"net/http"
 )
 
-type HttpErrorHandler interface {
-	HandleHttpError(err error, ctx Context)
-}
-
-type httpErrorHandler struct{}
-
-func (heh *httpErrorHandler) HandleHttpError(err error, ctx Context) {
+// This is defaultErrorHandler
+func DefaultErrorHandler(err error, ctx Context) {
 	if ctx.GetResponse().IsCommitted {
 		return
 	}
@@ -36,5 +31,4 @@ func (heh *httpErrorHandler) HandleHttpError(err error, ctx Context) {
 
 	// Send response
 	err = ctx.JSON(httpErr.Code, message)
-	_ = err
 }

--- a/error_handler.go
+++ b/error_handler.go
@@ -30,5 +30,6 @@ func DefaultErrorHandler(err error, ctx Context) {
 	}
 
 	// Send response
-	ctx.JSON(httpErr.Code, message)
+	err = ctx.JSON(httpErr.Code, message)
+	_ = err
 }

--- a/error_handler.go
+++ b/error_handler.go
@@ -30,5 +30,5 @@ func DefaultErrorHandler(err error, ctx Context) {
 	}
 
 	// Send response
-	err = ctx.JSON(httpErr.Code, message)
+	ctx.JSON(httpErr.Code, message)
 }

--- a/handler_type.go
+++ b/handler_type.go
@@ -7,3 +7,5 @@ type HandlerFunc func(ctx Context) error
 type MiddlewareFunc func(next HandlerFunc) HandlerFunc
 
 type LeafHandler func(leaf Leaf)
+
+type ErrorHandlerFunc func(err error, ctx Context)

--- a/poteto.go
+++ b/poteto.go
@@ -99,7 +99,7 @@ type Poteto interface {
 
 type poteto struct {
 	router          Router
-	errorHandler    HttpErrorHandler
+	ErrorHandler    ErrorHandlerFunc
 	middlewareTree  MiddlewareTree
 	logger          any
 	cache           sync.Pool
@@ -126,7 +126,7 @@ func New() Poteto {
 
 	return &poteto{
 		router:          NewRouter(),
-		errorHandler:    &httpErrorHandler{},
+		ErrorHandler:    DefaultErrorHandler,
 		middlewareTree:  NewMiddlewareTree(),
 		option:          DefaultPotetoOption,
 		potetoWorkflows: NewPotetoWorkflows(),
@@ -136,7 +136,7 @@ func New() Poteto {
 func NewWithOption(option PotetoOption) Poteto {
 	return &poteto{
 		router:          NewRouter(),
-		errorHandler:    &httpErrorHandler{},
+		ErrorHandler:    DefaultErrorHandler,
 		middlewareTree:  NewMiddlewareTree(),
 		option:          option,
 		potetoWorkflows: NewPotetoWorkflows(),
@@ -209,7 +209,7 @@ func (p *poteto) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	middlewares := p.middlewareTree.SearchMiddlewares(r.URL.Path)
 	handler = p.applyMiddleware(middlewares, handler)
 	if err := handler(ctx); err != nil {
-		p.errorHandler.HandleHttpError(err, ctx)
+		p.ErrorHandler(err, ctx)
 	}
 
 	// cached context


### PR DESCRIPTION
## Check

- [x] I've checked pass linter \* required
- [x] I've checked pass ut \* required
- [x] I've written ut for change

## Issue
- https://github.com/poteto-go/poteto/issues/301

## Change
ErrorHandler

```go
yourHandler := func(err error, ctx poteto.Context) {
//...
}

p := poteto.New()
p.ErrorHanlder = yourHandler
```